### PR TITLE
Remove GTPU tunnel when E-RAB is released

### DIFF
--- a/srsenb/src/stack/rrc/rrc_ue.cc
+++ b/srsenb/src/stack/rrc/rrc_ue.cc
@@ -1052,6 +1052,7 @@ bool rrc::ue::release_erabs()
 
 int rrc::ue::release_erab(uint32_t erab_id)
 {
+  bearer_list.rem_gtpu_bearer(erab_id);
   return bearer_list.release_erab(erab_id);
 }
 


### PR DESCRIPTION
Since the GTPU tunnels were not removed upon release of E-RAB,
the max count of tunnels were reached resulting in not able to
have successful E-RAB setup in subsequent attempt