### PR TITLE
Fix for crashing E-RABSetupRequest with E-RAB ID > 12

### DIFF
--- a/lib/include/srsran/interfaces/sched_interface.h
+++ b/lib/include/srsran/interfaces/sched_interface.h
@@ -40,7 +40,7 @@ public:
 
   const static int MAX_SIB_PAYLOAD_LEN = 2048;
   const static int MAX_SIBS            = 16;
-  const static int MAX_LC              = 11;
+  const static int MAX_LC              = 14;
   const static int MAX_LC_GROUP        = 4;
   const static int MAX_DATA_LIST       = 32;
   const static int MAX_RAR_LIST        = 8;

--- a/lib/include/srsran/interfaces/sched_interface.h
+++ b/lib/include/srsran/interfaces/sched_interface.h
@@ -40,7 +40,7 @@ public:
 
   const static int MAX_SIB_PAYLOAD_LEN = 2048;
   const static int MAX_SIBS            = 16;
-  const static int MAX_LC              = 14;
+  const static int MAX_LC              = 11;
   const static int MAX_LC_GROUP        = 4;
   const static int MAX_DATA_LIST       = 32;
   const static int MAX_RAR_LIST        = 8;

--- a/lib/src/upper/pdcp.cc
+++ b/lib/src/upper/pdcp.cc
@@ -172,9 +172,9 @@ void pdcp::del_bearer(uint32_t lcid)
   }
   if (valid_lcid(lcid)) {
     pdcp_array.erase(lcid);
-    logger.warning("Deleted PDCP bearer %s", rrc->get_rb_name(lcid));
+    logger.info("Deleted PDCP bearer with LCID %d", lcid);
   } else {
-    logger.warning("Can't delete bearer %s. Bearer doesn't exist.", rrc->get_rb_name(lcid));
+    logger.warning("Can't delete bearer with LCID %d. Bearer doesn't exist.", lcid);
   }
 }
 

--- a/srsenb/hdr/stack/rrc/rrc_bearer_cfg.h
+++ b/srsenb/hdr/stack/rrc/rrc_bearer_cfg.h
@@ -79,6 +79,7 @@ public:
       uint32_t addr     = 0;
     };
     uint8_t                                     id = 0;
+    uint32_t                                    lcid = 0;
     asn1::s1ap::erab_level_qos_params_s         qos_params;
     asn1::bounded_bitstring<1, 160, true, true> address;
     uint32_t                                    teid_out = 0;

--- a/srsenb/src/stack/rrc/mac_controller.cc
+++ b/srsenb/src/stack/rrc/mac_controller.cc
@@ -322,7 +322,8 @@ void mac_controller::set_scell_activation(const std::bitset<SRSRAN_MAX_CARRIERS>
 void mac_controller::set_drb_activation(bool active)
 {
   for (const drb_to_add_mod_s& drb : bearer_list.get_established_drbs()) {
-    current_sched_ue_cfg.ue_bearers[drb_to_lcid((lte_drb)drb.drb_id)].direction =
+    auto erab_it = bearer_list.get_erabs().find(drb.drb_id + 4);
+    current_sched_ue_cfg.ue_bearers[erab_it->second.lcid].direction =
         active ? sched_interface::ue_bearer_cfg_t::BOTH : sched_interface::ue_bearer_cfg_t::IDLE;
   }
 }

--- a/srsenb/src/stack/rrc/rrc_bearer_cfg.cc
+++ b/srsenb/src/stack/rrc/rrc_bearer_cfg.cc
@@ -234,29 +234,28 @@ int bearer_cfg_handler::add_erab(uint8_t                                        
     return SRSRAN_ERROR;
   }
 
-  uint8_t lcid = 3; // first E-RAB with DRB1 gets LCID3
-  for (const auto& drb : current_drbs) {
-    if (drb.lc_ch_id == lcid) {
-      lcid++;
+  uint32_t lcid;
+  // Check for used LCID, LCID for DRB 3-10
+  for (lcid = 3; lcid <= SRSRAN_N_RADIO_BEARERS; ++lcid) {
+    bool used = false;
+    for (std::map<uint8_t, erab_t>::iterator it = erabs.begin(); it != erabs.end(); ++it) {
+      if (it->second.lcid == lcid) {
+        // LCID already used so pick next LCID
+        used = true;
+        break;
+      }
+    }
+    if (used == false) {
+      break;
     }
   }
-  if (lcid > srsenb::sched_interface::MAX_LC) {
-    logger->error("Can't allocate LCID for ERAB id=%d", erab_id);
+  if (lcid >= SRSRAN_N_RADIO_BEARERS) {
+    logger->error("No logical channel available");
     cause.set_radio_network().value = asn1::s1ap::cause_radio_network_opts::radio_res_not_available;
     return SRSRAN_ERROR;
   }
 
-  uint8_t drbid = lcid - 2; // first E-RAB will be DRB1 on LCID3
-  for (const auto& drb : current_drbs) {
-    if (drb.drb_id == drbid) {
-      drbid++;
-    }
-  }
-  if (drbid > srsran::MAX_LTE_DRB_ID) {
-    logger->error("Can't allocate DRB ID for ERAB id=%d", erab_id);
-    cause.set_radio_network().value = asn1::s1ap::cause_radio_network_opts::radio_res_not_available;
-    return SRSRAN_ERROR;
-  }
+  uint8_t drbid = erab_id - 4; // Map e.g. E-RAB 5 == DRB1
 
   auto qci_it = cfg->qci_cfg.find(qos.qci);
   if (qci_it == cfg->qci_cfg.end() or not qci_it->second.configured) {
@@ -275,6 +274,7 @@ int bearer_cfg_handler::add_erab(uint8_t                                        
   erabs[erab_id].qos_params = qos;
   erabs[erab_id].address    = addr;
   erabs[erab_id].teid_out   = teid_out;
+  erabs[erab_id].lcid       = lcid;
 
   if (addr.length() > 32) {
     logger->error("Only addresses with length <= 32 are supported");
@@ -407,7 +407,7 @@ srsran::expected<uint32_t> bearer_cfg_handler::add_gtpu_bearer(uint32_t         
   erab_t::gtpu_tunnel bearer;
   bearer.teid_out                   = teid_out;
   bearer.addr                       = addr;
-  srsran::expected<uint32_t> teidin = gtpu->add_bearer(rnti, erab.id - 2, addr, teid_out, props);
+  srsran::expected<uint32_t> teidin = gtpu->add_bearer(rnti, erab.lcid, addr, teid_out, props);
   if (teidin.is_error()) {
     logger->error("Adding erab_id=%d to GTPU", erab_id);
     return srsran::default_error_t();
@@ -419,7 +419,13 @@ srsran::expected<uint32_t> bearer_cfg_handler::add_gtpu_bearer(uint32_t         
 
 void bearer_cfg_handler::rem_gtpu_bearer(uint32_t erab_id)
 {
-  gtpu->rem_bearer(rnti, erab_id - 2);
+  auto it = erabs.find(erab_id);
+  if (it != erabs.end()) {
+    // Map e.g. E-RAB 5 to LCID 3 (==DRB1)
+    gtpu->rem_bearer(rnti, it->second.lcid);
+  } else {
+    logger->error("Removing erab_id=%d to GTPU\n", erab_id);
+  }
 }
 
 void bearer_cfg_handler::fill_pending_nas_info(asn1::rrc::rrc_conn_recfg_r8_ies_s* msg)

--- a/srsenb/src/stack/rrc/rrc_mobility.cc
+++ b/srsenb/src/stack/rrc/rrc_mobility.cc
@@ -582,7 +582,7 @@ rrc::ue::rrc_mobility::s1_source_ho_st::start_enb_status_transfer(const asn1::s1
 
   for (const auto& erab_pair : rrc_ue->bearer_list.get_erabs()) {
     s1ap_interface_rrc::bearer_status_info b    = {};
-    uint8_t                                lcid = erab_pair.second.id - 2u;
+    uint8_t                                lcid = erab_pair.second.lcid;
     b.erab_id                                   = erab_pair.second.id;
     srsran::pdcp_lte_state_t pdcp_state         = {};
     if (not rrc_enb->pdcp->get_bearer_state(rrc_ue->rnti, lcid, &pdcp_state)) {

--- a/srsenb/src/stack/rrc/rrc_ue.cc
+++ b/srsenb/src/stack/rrc/rrc_ue.cc
@@ -1056,7 +1056,6 @@ bool rrc::ue::setup_erabs(const asn1::s1ap::erab_to_be_setup_list_ctxt_su_req_l&
 bool rrc::ue::release_erabs()
 {
   for (const auto& erab_it : bearer_list.get_erabs()) {
-    bearer_list.rem_gtpu_bearer(erab_it.second.id);
     parent->rlc->del_bearer(rnti, erab_it.second.lcid);
     parent->pdcp->del_bearer(rnti, erab_it.second.lcid);
   }


### PR DESCRIPTION
Fixes #658. But also needs the fix in this PR - https://github.com/srsran/srsRAN/pull/657

Since number of Logical Channels are 0 to 10 (both inclusive) and only 3-10 are used for DRBs.
And, maximum DRBs an UE can have is 11 at any time. Therefore there is need to handle these DRBs
per UE with Logical Channels from 3 to 10. This commit address this issue by not relying on simple
calculation of LCID based on E-RAB ID (i.e. LCID = E-RAB - 2) or DRB ID. But rather keep track
of used LCID and assign unused ones when a new bearer needs to be created. If all LCIDs are used up
then eNB will respond to CN with a cause mentioning radio_res_not_available