### PR TITLE
Minor srsepc proposed fixes 

### DIFF
--- a/srsepc/src/mme/nas.cc
+++ b/srsepc/src/mme/nas.cc
@@ -710,7 +710,7 @@ bool nas::handle_service_request(uint32_t                m_tmsi,
     nas_ctx->reset();
     // But don't erase imsi
     emm_ctx->imsi  = imsi;
-    //emm_ctx->state = EMM_STATE_DEREGISTERED;
+    emm_ctx->state = EMM_STATE_DEREGISTERED;
     memcpy(&ecm_ctx->enb_sri, enb_sri, sizeof(struct sctp_sndrcvinfo));
     ecm_ctx->enb_ue_s1ap_id = enb_ue_s1ap_id;
     ecm_ctx->mme_ue_s1ap_id = s1ap->get_next_mme_ue_s1ap_id();

--- a/srsepc/src/mme/nas.cc
+++ b/srsepc/src/mme/nas.cc
@@ -708,6 +708,9 @@ bool nas::handle_service_request(uint32_t                m_tmsi,
 
     // Reset and store context with new mme s1ap id
     nas_ctx->reset();
+    // But don't erase imsi
+    emm_ctx->imsi  = imsi;
+    //emm_ctx->state = EMM_STATE_DEREGISTERED;
     memcpy(&ecm_ctx->enb_sri, enb_sri, sizeof(struct sctp_sndrcvinfo));
     ecm_ctx->enb_ue_s1ap_id = enb_ue_s1ap_id;
     ecm_ctx->mme_ue_s1ap_id = s1ap->get_next_mme_ue_s1ap_id();

--- a/srsepc/src/mme/s1ap.cc
+++ b/srsepc/src/mme/s1ap.cc
@@ -375,8 +375,8 @@ bool s1ap::add_nas_ctx_to_mme_ue_s1ap_id_map(nas* nas_ctx)
     return false;
   }
   if (nas_ctx->m_emm_ctx.imsi != 0) {
-    std::map<uint32_t, nas*>::iterator ctx_it2 = m_mme_ue_s1ap_id_to_nas_ctx.find(nas_ctx->m_ecm_ctx.mme_ue_s1ap_id);
-    if (ctx_it2 != m_mme_ue_s1ap_id_to_nas_ctx.end() && ctx_it2->second != nas_ctx) {
+    std::map<uint64_t, nas*>::iterator ctx_it2 = m_imsi_to_nas_ctx.find(nas_ctx->m_emm_ctx.imsi);
+    if (ctx_it2 != m_imsi_to_nas_ctx.end() && ctx_it2->second != nas_ctx) {
       m_logger.error("Context identified with MME UE S1AP Id does not match context identified by IMSI.");
       return false;
     }


### PR DESCRIPTION
When adding a new NAS context to the MME UE ID map, in the check that
the new NAS context matches the context identified by the IMSI, pull from
the IMSI map for the check, not the MME UE ID map.

When resetting the NAS context on an service request integrity check
failure, don't zero the context IMSI. This seems to help with a UE
rejoining the EPC after an extended radio link failure with the ENB.