### PR TITLE
emergency handler for NAS PCAP to close file

### DIFF
--- a/lib/include/srsran/common/nas_pcap.h
+++ b/lib/include/srsran/common/nas_pcap.h
@@ -31,22 +31,17 @@ namespace srsran {
 class nas_pcap
 {
 public:
-  nas_pcap()
-  {
-    enable_write = false;
-    ue_id        = 0;
-    pcap_file    = NULL;
-  }
+  nas_pcap();
   void enable();
   uint32_t open(std::string filename_, uint32_t ue_id = 0, srsran_rat_t rat_type = srsran_rat_t::lte);
   void close();
   void write_nas(uint8_t* pdu, uint32_t pdu_len_bytes);
 
 private:
-  bool        enable_write;
+  bool        enable_write = false;
   std::string filename;
-  FILE*       pcap_file;
-  uint32_t    ue_id;
+  FILE*       pcap_file = nullptr;
+  uint32_t    ue_id     = 0;
   void        pack_and_write(uint8_t* pdu, uint32_t pdu_len_bytes);
 };
 

--- a/lib/src/common/nas_pcap.cc
+++ b/lib/src/common/nas_pcap.cc
@@ -22,9 +22,21 @@
 #include "srsran/common/nas_pcap.h"
 #include "srsran/common/pcap.h"
 #include "srsran/srsran.h"
+#include "srsran/support/emergency_handlers.h"
 #include <stdint.h>
 
 namespace srsran {
+
+/// Try to flush the contents of the pcap class before the application is killed.
+static void emergency_cleanup_handler(void* data)
+{
+  reinterpret_cast<nas_pcap*>(data)->close();
+}
+
+nas_pcap::nas_pcap()
+{
+  add_emergency_cleanup_handler(emergency_cleanup_handler, this);
+}
 
 void nas_pcap::enable()
 {
@@ -51,6 +63,7 @@ void nas_pcap::close()
 {
   fprintf(stdout, "Saving NAS PCAP file (DLT=%d) to %s \n", NAS_LTE_DLT, filename.c_str());
   DLT_PCAP_Close(pcap_file);
+  pcap_file = nullptr;
 }
 
 void nas_pcap::write_nas(uint8_t* pdu, uint32_t pdu_len_bytes)


### PR DESCRIPTION
This adds emergency handlers for NAS PCAPs to ensure the files are flushed/closed when the application is killed.

Emergency handlers were added with 2c1e9c0c55712601ed7da637d11dade2b09fe3da (thanks @faluco!) to flush logs/PCAPs but NAS is missing.