### PR TITLE
srsUE: Add option to filter N_id_1 / SSS to configuration

### DIFF
--- a/lib/include/srsran/interfaces/ue_phy_interfaces.h
+++ b/lib/include/srsran/interfaces/ue_phy_interfaces.h
@@ -45,6 +45,7 @@ struct phy_args_t {
   std::map<uint32_t, uint32_t> ul_earfcn_map;    // Map linking DL EARFCN and UL EARFCN
 
   int force_N_id_2 = -1; // Cell identity within the identity group (PSS) to filter.
+  int force_N_id_1 = -1; // Cell identity group (SSS) to filter.
 
   float dl_freq = -1.0f;
   float ul_freq = -1.0f;

--- a/srsue/hdr/phy/search.h
+++ b/srsue/hdr/phy/search.h
@@ -45,7 +45,7 @@ public:
 
   explicit search(srslog::basic_logger& logger) : logger(logger) {}
   ~search();
-  void     init(srsran::rf_buffer_t& buffer_, uint32_t nof_rx_channels, search_callback* parent, int force_N_id_2_);
+  void     init(srsran::rf_buffer_t& buffer_, uint32_t nof_rx_channels, search_callback* parent, int force_N_id_2_, int force_N_id_1_);
   void     reset();
   float    get_last_cfo();
   void     set_agc_enable(bool enable);
@@ -59,6 +59,7 @@ private:
   srsran_ue_cellsearch_t cs           = {};
   srsran_ue_mib_sync_t   ue_mib_sync  = {};
   int                    force_N_id_2 = 0;
+  int                    force_N_id_1 = 0;
 };
 
 }; // namespace srsue

--- a/srsue/src/main.cc
+++ b/srsue/src/main.cc
@@ -418,6 +418,10 @@ static int parse_args(all_args_t* args, int argc, char* argv[])
      bpo::value<int>(&args->phy.force_N_id_2)->default_value(-1),
      "Force using a specific PSS (set to -1 to allow all PSSs).")
 
+    ("phy.force_N_id_1",
+     bpo::value<int>(&args->phy.force_N_id_1)->default_value(-1),
+     "Force using a specific SSS (set to -1 to allow all SSSs).")
+
     // PHY NR args
     ("phy.nr.store_pdsch_ko",
       bpo::value<bool>(&args->phy.nr_store_pdsch_ko)->default_value(false),

--- a/srsue/src/phy/search.cc
+++ b/srsue/src/phy/search.cc
@@ -55,7 +55,7 @@ search::~search()
   srsran_ue_cellsearch_free(&cs);
 }
 
-void search::init(srsran::rf_buffer_t& buffer_, uint32_t nof_rx_channels, search_callback* parent, int force_N_id_2_)
+void search::init(srsran::rf_buffer_t& buffer_, uint32_t nof_rx_channels, search_callback* parent, int force_N_id_2_, int force_N_id_1_)
 {
   p = parent;
 
@@ -74,6 +74,7 @@ void search::init(srsran::rf_buffer_t& buffer_, uint32_t nof_rx_channels, search
   p->set_ue_sync_opts(&cs.ue_sync, 0);
 
   force_N_id_2 = force_N_id_2_;
+  force_N_id_1 = force_N_id_1_;
 }
 
 void search::set_cp_en(bool enable)
@@ -134,6 +135,21 @@ search::ret_code search::run(srsran_cell_t* cell_, std::array<uint8_t, SRSRAN_BC
     Info("SYNC:  Could not find any cell in this frequency");
     return CELL_NOT_FOUND;
   }
+
+  if (force_N_id_1 >= 0 && force_N_id_1 < SRSRAN_NOF_NID_1) {
+    bool N_id_1_found = false;
+    for (uint32_t N_id_2 = 0; N_id_2 < SRSRAN_NOF_NID_2; N_id_2++) {
+      if (found_cells[N_id_2].cell_id / SRSRAN_NOF_NID_2 == (uint32_t)force_N_id_1) {
+        N_id_1_found = true;
+        max_peak_cell = N_id_2;
+      }
+    }
+    if (!N_id_1_found) {
+      Info("SYNC:  Could not find any cell in this SSS");
+      return CELL_NOT_FOUND;
+    }
+  }
+
   // Save result
   new_cell.id         = found_cells[max_peak_cell].cell_id;
   new_cell.cp         = found_cells[max_peak_cell].cp;

--- a/srsue/src/phy/sync.cc
+++ b/srsue/src/phy/sync.cc
@@ -91,7 +91,7 @@ void sync::init(srsran::radio_interface_phy* _radio,
   }
 
   // Initialize cell searcher
-  search_p.init(sf_buffer, nof_rf_channels, this, worker_com->args->force_N_id_2);
+  search_p.init(sf_buffer, nof_rf_channels, this, worker_com->args->force_N_id_2, worker_com->args->force_N_id_1);
   search_p.set_cp_en(worker_com->args->detect_cp);
   // Initialize SFN synchronizer, it uses only pcell buffer
   sfn_p.init(&ue_sync, worker_com->args, sf_buffer, sf_buffer.size());

--- a/srsue/ue.conf.example
+++ b/srsue/ue.conf.example
@@ -343,6 +343,9 @@ enable = false
 # nof_in_sync_events:     Number of PHY in-sync events before sending an in-sync event to RRC
 # nof_out_of_sync_events: Number of PHY out-sync events before sending an out-sync event to RRC
 #
+# force_N_id_2: Force using a specific PSS (set to -1 to allow all PSSs).
+# force_N_id_1: Force using a specific SSS (set to -1 to allow all SSSs).
+#
 #####################################################################
 [phy]
 #rx_gain_offset      = 62
@@ -373,6 +376,9 @@ enable = false
 #in_sync_snr_db_th      = 3.0
 #nof_in_sync_events     = 10
 #nof_out_of_sync_events = 20
+
+#force_N_id_2           = 1
+#force_N_id_1           = 10
 
 #####################################################################
 # PHY NR specific configuration options


### PR DESCRIPTION
Hey!
This change will allow forcing the srsUE to select a specific SSS and in my humble opinion will help reducing interference to local operators.
I compiled it and tested it manually (and I ran the existing tests). I found it quite difficult to test this specific feature using the current tests, so any help on that (unless you are fine with merging it without specific tests) would be appreciated.

Thanks for dedicating time!