### PR TITLE
add net_name to epc.conf help

### DIFF
--- a/srsepc/epc.conf.example
+++ b/srsepc/epc.conf.example
@@ -10,6 +10,8 @@
 # tac:              16-bit Tracking Area Code.
 # mcc:              Mobile Country Code
 # mnc:              Mobile Network Code
+# full_net_name     Display Name of the Network
+# short_net_name    Short Display Name of the Network
 # apn:		          Set Access Point Name (APN)
 # mme_bind_addr:    IP bind addr to listen for eNB S1-MME connnections
 # dns_addr:         DNS server address for the UEs


### PR DESCRIPTION
The `full_net_name` and `short_net_name` configuration options were not present in the MME configuration documentation of epc.conf.