### PR TITLE
Fix bsr updating issue of eMBMS bearer

### DIFF
--- a/lib/src/rlc/rlc.cc
+++ b/lib/src/rlc/rlc.cc
@@ -467,6 +467,9 @@ int rlc::add_bearer_mrb(uint32_t lcid)
       logger.error("Error configuring RLC entity.");
       return SRSRAN_ERROR;
     }
+
+    rlc_entity->set_bsr_callback(bsr_callback);
+
     if (rlc_array_mrb.count(lcid) == 0) {
       if (not rlc_array_mrb.insert(rlc_map_pair_t(lcid, std::move(rlc_entity))).second) {
         logger.error("Error inserting RLC entity in to array.");


### PR DESCRIPTION
I was following [the official application note of eMBMB](https://docs.srsran.com/en/latest/app_notes/source/embms/source/index.html) step-by-step. Unfortunately, the data was unable transfer to UE.
The log of srseNB shows that the SDU goes into RLC layer, then stuck there.
```plain
// Transmitting "123\n" from MBMS-GW
[RLC    ] [W] RLC LCID 1 doesn't exist. Ignoring queue check
[RLC    ] [W] LCID 1 doesn't exist.
[PDCP   ] [I] TX DRB1 PDU, SN=0, integrity=none, encryption=none
   0000: 80 00 45 00 00 20 d0 04 40 00 01 11 8a 9d 2d 2d
   0010: 00 fe ef ff 01 01 ce ea 0d 80 00 0c a0 03 31 32
   0020: 33 0a
[RLC    ] [I] MRB1 Tx SDU (34 B, tx_sdu_queue_len=1)
   0000: 80 00 45 00 00 20 d0 04 40 00 01 11 8a 9d 2d 2d
   0010: 00 fe ef ff 01 01 ce ea 0d 80 00 0c a0 03 31 32
   0020: 33 0a
[MAC    ] [I] [ 1281] MCH Sched Info: LCID: 1, Stop: 0, tti is 1281

// Transmitting "456\n" from MBMS-GW
[RLC    ] [W] RLC LCID 1 doesn't exist. Ignoring discard SDU
[RLC    ] [W] RLC LCID 1 doesn't exist. Ignoring queue check
[RLC    ] [W] LCID 1 doesn't exist.
[PDCP   ] [I] TX DRB1 PDU, SN=1, integrity=none, encryption=none
   0000: 80 01 45 00 00 20 d0 d1 40 00 01 11 89 d0 2d 2d
   0010: 00 fe ef ff 01 01 ce ea 0d 80 00 0c 9a 00 34 35
   0020: 36 0a
[RLC    ] [I] MRB1 Tx SDU (34 B, tx_sdu_queue_len=2)
   0000: 80 01 45 00 00 20 d0 d1 40 00 01 11 89 d0 2d 2d
   0010: 00 fe ef ff 01 01 ce ea 0d 80 00 0c 9a 00 34 35
   0020: 36 0a

// MCH is continuously scheduled, but the "Stop" always stays "0", means that no MTCH was scheduled.
[MAC    ] [I] [ 4481] MCH Sched Info: LCID: 1, Stop: 0, tti is 4481 
[MAC    ] [I] [ 5121] MCH Sched Info: LCID: 1, Stop: 0, tti is 5121
[MAC    ] [I] [ 5761] MCH Sched Info: LCID: 1, Stop: 0, tti is 5761 
[MAC    ] [I] [ 6401] MCH Sched Info: LCID: 1, Stop: 0, tti is 6401
```
After some research, I found the root cause was that the state of `rlc_um_base_tx::tx_sdu_queue` didn't update after writing.
Lead to MTCH will never be scheduled because MAC layer didn't known there's data queued in RLC layer.

I fixd this issue by registering `bsr_callback` while adding eMBMS bearer to RLC.
With this little patch, the MTCH is able to be scheduled, and the eMBMS functions as well as before.
```plain
// Transmitting "123\n" from MBMS-GW
[MAC    ] [I] [ 9601] MCH Sched Info: LCID: 1, Stop: 0, tti is 9601 
[RLC    ] [W] RLC LCID 1 doesn't exist. Ignoring queue check
[RLC    ] [W] LCID 1 doesn't exist.
[PDCP   ] [I] TX DRB1 PDU, SN=0, integrity=none, encryption=none
   0000: 80 00 45 00 00 20 b6 b5 40 00 01 11 a3 ec 2d 2d
   0010: 00 fe ef ff 01 01 ae b8 0d 80 00 0c c0 35 31 32
   0020: 33 0a
[RLC    ] [I] MRB1 Tx SDU (34 B, tx_sdu_queue_len=1)
   0000: 80 00 45 00 00 20 b6 b5 40 00 01 11 a3 ec 2d 2d
   0010: 00 fe ef ff 01 01 ae b8 0d 80 00 0c c0 35 31 32
   0020: 33 0a
[RLC    ] [D] Buffer state: rnti=0xfffd, lcid=1, tx_queue=36, prio_tx_queue=0
[MAC    ] [I] [    1] MCH Sched Info: LCID: 1, Stop: 1, tti is 1 
[RLC    ] [D] MAC opportunity - 36 bytes
[RLC    ] [D] pdu_space=36, head_len=1
[RLC    ] [D] MRB1 adding new SDU segment - 34 bytes of 34 remaining
[RLC    ] [D] MRB1 Complete SDU scheduled for tx. Stack latency (last/average): 0/0 us
[RLC    ] [I] MRB1 Tx PDU SN=0 (35 B)
   0000: 00 80 00 45 00 00 20 b6 b5 40 00 01 11 a3 ec 2d
   0010: 2d 00 fe ef ff 01 01 ae b8 0d 80 00 0c c0 35 31
   0020: 32 33 0a
[RLC    ] [D] MRB1 vt_us = 1
[RLC    ] [D] Buffer state: rnti=0xfffd, lcid=1, tx_queue=0, prio_tx_queue=0
[RLC    ] [I] lcid=0, rx_rate_mbps=0.00 (real=0.00), tx_rate_mbps=0.00 (real=0.00)
[RLC    ] [I] lcid=1, rx_rate_mbps=0.00 (real=0.00), tx_rate_mbps=0.00 (real=0.00)
[RLC    ] [I] lcid=2, rx_rate_mbps=0.00 (real=0.00), tx_rate_mbps=0.00 (real=0.00)
[RLC    ] [I] lcid=3, rx_rate_mbps=0.00 (real=0.00), tx_rate_mbps=0.00 (real=0.00)
[RLC    ] [I] lcid=0, rx_rate_mbps=0.00 (real=0.00), tx_rate_mbps=0.00 (real=0.00)
[RLC    ] [I] MCH_LCID=1, rx_rate_mbps=0.00

// Transmitting "456\n" from MBMS-GW
[MAC    ] [I] [ 1281] MCH Sched Info: LCID: 1, Stop: 0, tti is 1281 
[PDCP   ] [I] Discard timer for SN=0 expired
[RLC    ] [W] RLC LCID 1 doesn't exist. Ignoring discard SDU
[RLC    ] [W] RLC LCID 1 doesn't exist. Ignoring queue check
[RLC    ] [W] LCID 1 doesn't exist.
[PDCP   ] [I] TX DRB1 PDU, SN=1, integrity=none, encryption=none
   0000: 80 01 45 00 00 20 b7 03 40 00 01 11 a3 9e 2d 2d
   0010: 00 fe ef ff 01 01 ae b8 0d 80 00 0c ba 32 34 35
   0020: 36 0a
[RLC    ] [I] MRB1 Tx SDU (34 B, tx_sdu_queue_len=1)
   0000: 80 01 45 00 00 20 b7 03 40 00 01 11 a3 9e 2d 2d
   0010: 00 fe ef ff 01 01 ae b8 0d 80 00 0c ba 32 34 35
   0020: 36 0a
[RLC    ] [D] Buffer state: rnti=0xfffd, lcid=1, tx_queue=36, prio_tx_queue=0
[MAC    ] [I] [ 1921] MCH Sched Info: LCID: 1, Stop: 1, tti is 1921 
[RLC    ] [D] MAC opportunity - 36 bytes
[RLC    ] [D] pdu_space=36, head_len=1
[RLC    ] [D] MRB1 adding new SDU segment - 34 bytes of 34 remaining
[RLC    ] [D] MRB1 Complete SDU scheduled for tx. Stack latency (last/average): 0/0 us
[RLC    ] [I] MRB1 Tx PDU SN=1 (35 B)
   0000: 01 80 01 45 00 00 20 b7 03 40 00 01 11 a3 9e 2d
   0010: 2d 00 fe ef ff 01 01 ae b8 0d 80 00 0c ba 32 34
   0020: 35 36 0a
[RLC    ] [D] MRB1 vt_us = 2
[RLC    ] [D] Buffer state: rnti=0xfffd, lcid=1, tx_queue=0, prio_tx_queue=0
```