### PR TITLE
NAS: Add configuration for LAC.

### DIFF
--- a/srsepc/epc.conf.example
+++ b/srsepc/epc.conf.example
@@ -21,6 +21,7 @@
 #                   (supported: EIA0 (rejected by most UEs), EIA1 (default), EIA2, EIA3
 # paging_timer:     Value of paging timer in seconds (T3413)
 # request_imeisv:   Request UE's IMEI-SV in security mode command
+# lac:              16-bit Location Area Code.
 #
 #####################################################################
 [mme]
@@ -36,6 +37,7 @@ encryption_algo = EEA0
 integrity_algo = EIA1
 paging_timer = 2
 request_imeisv = false
+lac = 0x0006
 
 #####################################################################
 # HSS configuration

--- a/srsepc/hdr/mme/nas.h
+++ b/srsepc/hdr/mme/nas.h
@@ -142,6 +142,7 @@ typedef struct {
   srsran::CIPHERING_ALGORITHM_ID_ENUM cipher_algo;
   srsran::INTEGRITY_ALGORITHM_ID_ENUM integ_algo;
   bool                                request_imeisv;
+  uint16_t                            lac;
 } nas_init_t;
 
 typedef struct {
@@ -280,6 +281,7 @@ private:
   std::string m_full_net_name;
   std::string m_short_net_name;
   bool        m_request_imeisv = false;
+  uint16_t    m_lac            = 0;
 
   // Timers timeout values
   uint16_t m_t3413 = 0;

--- a/srsepc/hdr/mme/s1ap_common.h
+++ b/srsepc/hdr/mme/s1ap_common.h
@@ -52,6 +52,7 @@ typedef struct {
   srsran::CIPHERING_ALGORITHM_ID_ENUM encryption_algo;
   srsran::INTEGRITY_ALGORITHM_ID_ENUM integrity_algo;
   bool                                request_imeisv;
+  uint16_t                            lac;
 } s1ap_args_t;
 
 typedef struct {

--- a/srsepc/src/main.cc
+++ b/srsepc/src/main.cc
@@ -97,6 +97,7 @@ void parse_args(all_args_t* args, int argc, char* argv[])
   string   hss_db_file;
   string   hss_auth_algo;
   string   log_filename;
+  string   lac;
 
   // Command line only options
   bpo::options_description general("General options");
@@ -124,6 +125,7 @@ void parse_args(all_args_t* args, int argc, char* argv[])
     ("mme.integrity_algo",  bpo::value<string>(&integrity_algo)->default_value("EIA1"),      "Set preferred integrity protection algorithm for NAS")
     ("mme.paging_timer",    bpo::value<uint16_t>(&paging_timer)->default_value(2),           "Set paging timer value in seconds (T3413)")
     ("mme.request_imeisv",  bpo::value<bool>(&request_imeisv)->default_value(false),         "Enable IMEISV request in Security mode command")
+    ("mme.lac",             bpo::value<string>(&lac)->default_value("0x01"),                 "Location Area Code")
     ("hss.db_file",         bpo::value<string>(&hss_db_file)->default_value("ue_db.csv"),    ".csv file that stores UE's keys")
     ("spgw.gtpu_bind_addr", bpo::value<string>(&spgw_bind_addr)->default_value("127.0.0.1"), "IP address of SP-GW for the S1-U connection")
     ("spgw.sgi_if_addr",    bpo::value<string>(&sgi_if_addr)->default_value("176.16.0.1"),   "IP address of TUN interface for the SGi connection")
@@ -226,6 +228,11 @@ void parse_args(all_args_t* args, int argc, char* argv[])
     std::stringstream sstr;
     sstr << std::hex << vm["mme.tac"].as<std::string>();
     sstr >> args->mme_args.s1ap_args.tac;
+  }
+  {
+    std::stringstream sstr;
+    sstr << std::hex << vm["mme.lac"].as<std::string>();
+    sstr >> args->mme_args.s1ap_args.lac;
   }
 
   // Convert MCC/MNC strings

--- a/srsepc/src/mme/nas.cc
+++ b/srsepc/src/mme/nas.cc
@@ -46,7 +46,8 @@ nas::nas(const nas_init_t& args, const nas_if_t& itf) :
   m_full_net_name(args.full_net_name),
   m_short_net_name(args.short_net_name),
   m_t3413(args.paging_timer),
-  m_request_imeisv(args.request_imeisv)
+  m_request_imeisv(args.request_imeisv),
+  m_lac(args.lac)
 {
   m_sec_ctx.integ_algo  = args.integ_algo;
   m_sec_ctx.cipher_algo = args.cipher_algo;
@@ -1550,7 +1551,7 @@ bool nas::pack_attach_accept(srsran::byte_buffer_t* nas_buffer)
   attach_accept.lai_present = true;
   attach_accept.lai.mcc     = mcc;
   attach_accept.lai.mnc     = mnc;
-  attach_accept.lai.lac     = 001;
+  attach_accept.lai.lac     = m_lac;
 
   attach_accept.ms_id_present    = true;
   attach_accept.ms_id.type_of_id = LIBLTE_MME_MOBILE_ID_TYPE_TMSI;

--- a/srsepc/src/mme/s1ap_nas_transport.cc
+++ b/srsepc/src/mme/s1ap_nas_transport.cc
@@ -81,6 +81,7 @@ void s1ap_nas_transport::init()
   m_nas_init.integ_algo     = m_s1ap->m_s1ap_args.integrity_algo;
   m_nas_init.cipher_algo    = m_s1ap->m_s1ap_args.encryption_algo;
   m_nas_init.request_imeisv = m_s1ap->m_s1ap_args.request_imeisv;
+  m_nas_init.lac            = m_s1ap->m_s1ap_args.lac;
 
   // Init NAS interface
   m_nas_if.s1ap = s1ap::get_instance();


### PR DESCRIPTION
Hey!
This change will allow configuring the LAC in the EMM information (previously it was hard coded to 1).

Thanks in advance!