### PR TITLE
Enable encryption at the UE for DRB added in reconfig

### DIFF
--- a/srsue/hdr/stack/ue_stack_lte.h
+++ b/srsue/hdr/stack/ue_stack_lte.h
@@ -224,6 +224,7 @@ private:
   srslog::basic_logger& rrc_logger;
   srslog::basic_logger& usim_logger;
   srslog::basic_logger& nas_logger;
+  srslog::basic_logger& nas5g_logger;
 
   // UE NR stack logging
   srslog::basic_logger& mac_nr_logger;

--- a/srsue/src/stack/rrc_nr/rrc_nr.cc
+++ b/srsue/src/stack/rrc_nr/rrc_nr.cc
@@ -2079,7 +2079,8 @@ bool rrc_nr::apply_drb_add_mod(const drb_to_add_mod_s& drb_cfg)
 
   srsran::pdcp_config_t pdcp_cfg = make_drb_pdcp_config_t(drb_cfg.drb_id, true, drb_cfg.pdcp_cfg);
   pdcp->add_bearer(lcid, pdcp_cfg);
-
+  pdcp->config_security(lcid, sec_cfg);
+  pdcp->enable_encryption(lcid);
   return true;
 }
 

--- a/srsue/src/stack/ue_stack_lte.cc
+++ b/srsue/src/stack/ue_stack_lte.cc
@@ -42,6 +42,7 @@ ue_stack_lte::ue_stack_lte() :
   rrc_logger(srslog::fetch_basic_logger("RRC", false)),
   usim_logger(srslog::fetch_basic_logger("USIM", false)),
   nas_logger(srslog::fetch_basic_logger("NAS", false)),
+  nas5g_logger(srslog::fetch_basic_logger("NAS5G", false)),
   mac_nr_logger(srslog::fetch_basic_logger("MAC-NR")),
   rrc_nr_logger(srslog::fetch_basic_logger("RRC-NR", false)),
   rlc_nr_logger(srslog::fetch_basic_logger("RLC-NR", false)),
@@ -128,6 +129,8 @@ int ue_stack_lte::init(const stack_args_t& args_)
   nas_logger.set_level(srslog::str_to_basic_level(args.log.nas_level));
   nas_logger.set_hex_dump_max_size(args.log.nas_hex_limit);
 
+  nas5g_logger.set_level(srslog::str_to_basic_level(args.log.nas_level));
+  nas5g_logger.set_hex_dump_max_size(args.log.nas_hex_limit);
   mac_nr_logger.set_level(srslog::str_to_basic_level(args.log.mac_level));
   mac_nr_logger.set_hex_dump_max_size(args.log.mac_hex_limit);
   rrc_nr_logger.set_level(srslog::str_to_basic_level(args.log.rrc_level));


### PR DESCRIPTION
Minor fix that allows to encrypt user data. 