### PR TITLE
enb,cfg_parser: Fix ac_barring_for_mo_data time typo.

### DIFF
--- a/srsenb/src/enb_cfg_parser.cc
+++ b/srsenb/src/enb_cfg_parser.cc
@@ -1922,7 +1922,7 @@ int parse_sib2(std::string filename, sib_type2_s* data)
 
   acbarring_data.add_field(
       make_asn1_enum_number_str_parser("factor", &data->ac_barr_info.ac_barr_for_mo_data.ac_barr_factor));
-  acbarring_data.add_field(make_asn1_enum_number_parser("fime", &data->ac_barr_info.ac_barr_for_mo_data.ac_barr_time));
+  acbarring_data.add_field(make_asn1_enum_number_parser("time", &data->ac_barr_info.ac_barr_for_mo_data.ac_barr_time));
   acbarring_data.add_field(make_asn1_bitstring_number_parser(
       "for_special_ac", &data->ac_barr_info.ac_barr_for_mo_data.ac_barr_for_special_ac));
 


### PR DESCRIPTION
Hey!
I think there is a typo here.
Tested it with wireshark.

Also, I think about adding documentation to sib2 configuration (in a different pr) but it will be pretty long, what do you think?

Thanks a lot!