### PR TITLE
probably mispelled property in pcap

### DIFF
--- a/srsenb/enb.conf.example
+++ b/srsenb/enb.conf.example
@@ -106,7 +106,7 @@ rx_gain = 40
 # To use the dissector, edit the preferences for DLT_USER to 
 # add an entry with DLT=150, Payload Protocol=s1ap.
 #
-# mac_enable:    Enable MAC layer packet captures (true/false)
+# enable:        Enable MAC layer packet captures (true/false)
 # filename:      File path to use for LTE MAC packet captures
 # nr_filename:   File path to use for NR MAC packet captures
 # s1ap_enable:   Enable or disable the PCAP.


### PR DESCRIPTION
In the pcap section, the documentation talks about the `mac_enable` property.
This property is not in the actual properties of the `[pcap]` section.
I thought it would be more probable to forget about the documentation property rather than the actual property name.
For this reason, I have changed the documentation from `mac_enable` to `enable`.
I have not executed any test on the change.

In the `enb_cfg_parser.cc` I have not found any reference to `mac_enable` but only to `enable`.