### PR TITLE
Introduce Configurable S1 Connection Timer

### DIFF
--- a/lib/include/srsran/interfaces/enb_s1ap_interfaces.h
+++ b/lib/include/srsran/interfaces/enb_s1ap_interfaces.h
@@ -42,7 +42,7 @@ struct s1ap_args_t {
   uint32_t    ts1_reloc_prep_timeout;
   uint32_t    ts1_reloc_overall_timeout;
   int32_t     max_s1_setup_retries;
-  int32_t     s1_connect_timer;
+  uint32_t     s1_connect_timer;
 };
 
 // S1AP interface for RRC

--- a/lib/include/srsran/interfaces/enb_s1ap_interfaces.h
+++ b/lib/include/srsran/interfaces/enb_s1ap_interfaces.h
@@ -42,6 +42,7 @@ struct s1ap_args_t {
   uint32_t    ts1_reloc_prep_timeout;
   uint32_t    ts1_reloc_overall_timeout;
   int32_t     max_s1_setup_retries;
+  int32_t     s1_connect_timer;
 };
 
 // S1AP interface for RRC

--- a/srsenb/enb.conf.example
+++ b/srsenb/enb.conf.example
@@ -387,6 +387,7 @@ nr_pdsch_mcs=28
 # rlf_release_timer_ms: Time taken by eNB to release UE context after it detects a RLF
 # rlf_min_ul_snr_estim: SNR threshold in dB below which the enb is notified with RLF ko
 # s1_setup_max_retries: Maximum amount of retries to setup the S1AP connection. If this value is exceeded, an alarm is written to the log. -1 means infinity.
+# s1_connect_timer:     Connection Retry Timer for S1 connection (seconds)
 # rx_gain_offset:       RX Gain offset to add to rx_gain to calibrate RSRP readings
 #####################################################################
 [expert]
@@ -423,4 +424,5 @@ nr_pdsch_mcs=28
 #rlf_release_timer_ms = 4000
 #rlf_min_ul_snr_estim = -2
 #s1_setup_max_retries = -1
+#s1_connect_timer = 10
 #rx_gain_offset = 62

--- a/srsenb/src/main.cc
+++ b/srsenb/src/main.cc
@@ -268,6 +268,7 @@ void parse_args(all_args_t* args, int argc, char* argv[])
     ("expert.ts1_reloc_overall_timeout", bpo::value<uint32_t>(&args->stack.s1ap.ts1_reloc_overall_timeout)->default_value(10000), "S1AP TS 36.413 TS1RelocOverall Expiry Timeout value in milliseconds.")
     ("expert.rlf_min_ul_snr_estim", bpo::value<int>(&args->stack.mac.rlf_min_ul_snr_estim)->default_value(-2), "SNR threshold in dB below which the eNB is notified with rlf ko.")
     ("expert.max_s1_setup_retries", bpo::value<int32_t>(&args->stack.s1ap.max_s1_setup_retries)->default_value(-1), "Max S1 setup retries")
+    ("expert.s1_connect_timer",  bpo::value<int32_t>(&args->stack.s1ap.s1_connect_timer)->default_value(10), "Connection Retry Timer for S1 connection (seconds)")
     ("expert.rx_gain_offset", bpo::value<float>(&args->phy.rx_gain_offset)->default_value(62), "RX Gain offset to add to rx_gain to calibrate RSRP readings")
 
     // eMBMS section

--- a/srsenb/src/main.cc
+++ b/srsenb/src/main.cc
@@ -268,7 +268,7 @@ void parse_args(all_args_t* args, int argc, char* argv[])
     ("expert.ts1_reloc_overall_timeout", bpo::value<uint32_t>(&args->stack.s1ap.ts1_reloc_overall_timeout)->default_value(10000), "S1AP TS 36.413 TS1RelocOverall Expiry Timeout value in milliseconds.")
     ("expert.rlf_min_ul_snr_estim", bpo::value<int>(&args->stack.mac.rlf_min_ul_snr_estim)->default_value(-2), "SNR threshold in dB below which the eNB is notified with rlf ko.")
     ("expert.max_s1_setup_retries", bpo::value<int32_t>(&args->stack.s1ap.max_s1_setup_retries)->default_value(-1), "Max S1 setup retries")
-    ("expert.s1_connect_timer",  bpo::value<int32_t>(&args->stack.s1ap.s1_connect_timer)->default_value(10), "Connection Retry Timer for S1 connection (seconds)")
+    ("expert.s1_connect_timer",  bpo::value<uint32_t>(&args->stack.s1ap.s1_connect_timer)->default_value(10), "Connection Retry Timer for S1 connection (seconds)")
     ("expert.rx_gain_offset", bpo::value<float>(&args->phy.rx_gain_offset)->default_value(62), "RX Gain offset to add to rx_gain to calibrate RSRP readings")
 
     // eMBMS section

--- a/srsenb/src/stack/s1ap/s1ap.cc
+++ b/srsenb/src/stack/s1ap/s1ap.cc
@@ -329,7 +329,7 @@ int s1ap::init(const s1ap_args_t& args_, rrc_interface_s1ap* rrc_)
     }
     s1setup_proc.launch();
   };
-  mme_connect_timer.set(10000, mme_connect_run);
+  mme_connect_timer.set(args.s1_connect_timer * 1000, mme_connect_run);
   // Setup S1Setup timeout
   s1setup_timeout              = task_sched.get_unique_timer();
   uint32_t s1setup_timeout_val = 5000;


### PR DESCRIPTION
I found myself wanting to reduce the re-try timer between S1 connection attempts.  This makes that timer configurable for those who might be interested in quicker (or slower) retries.