### PR TITLE
add length check on idx

### DIFF
--- a/lib/src/asn1/liblte_mme.cc
+++ b/lib/src/asn1/liblte_mme.cc
@@ -3019,9 +3019,13 @@ LIBLTE_ERROR_ENUM liblte_mme_unpack_emergency_number_list_ie(uint8**            
     emerg_num_list->N_emerg_nums = 0;
     while (length < sent_length) {
       idx                                               = emerg_num_list->N_emerg_nums;
+      //add length check on emergency number list
+      if (idx >= LIBLTE_MME_EMERGENCY_NUMBER_LIST_MAX_SIZE) {
+        return (err);
+      }
       emerg_num_list->emerg_num[idx].N_emerg_num_digits = ((*ie_ptr)[length++] - 1) * 2;
       if (emerg_num_list->emerg_num[idx].N_emerg_num_digits > LIBLTE_MME_EMERGENCY_NUMBER_MAX_NUM_DIGITS) {
-        return err;
+        return (err);
       }
 
       emerg_num_list->emerg_num[idx].emerg_service_cat =


### PR DESCRIPTION
Hi,I found ``` LIBLTE_MME_EMERGENCY_NUMBER_LIST_MAX_SIZE``` is 12. So the largest number of idx(also N_emerg_nums) should less than 12.

The define of ``` LIBLTE_MME_EMERGENCY_NUMBER_LIST_MAX_SIZE ``` is here.
```cpp
#define LIBLTE_MME_EMERGENCY_NUMBER_LIST_MAX_SIZE 12
```
It used in:
```cpp
typedef struct {
  LIBLTE_MME_EMERGENCY_NUMBER_STRUCT emerg_num[LIBLTE_MME_EMERGENCY_NUMBER_LIST_MAX_SIZE];
  uint32                             N_emerg_nums;
} LIBLTE_MME_EMERGENCY_NUMBER_LIST_STRUCT;
```
But you haven't check the length of idx, that maybe cause the crash of UE, so I add the length check on idx.

The follow is my test.

in function srsepc/sec/mme/nas.cc/nas::pack_attach_accept,I enable the emergency bumber.
```cpp
attach_accept.emerg_num_list_present = true;
```
and set the attach_accept.emerg_num_list.
```cpp
LIBLTE_MME_EMERGENCY_NUMBER_LIST_STRUCT lists;
LIBLTE_MME_EMERGENCY_NUMBER_STRUCT num;
lists.N_emerg_nums = 14;
attach_accept.emerg_num_list = lists;
```
Then I changed the sent length of emergency number in ``` liblte_mme_pack_emergency_number_list_ie``` function.
```cpp
(*ie_ptr)[0] = 0xff;
```
When srsue received the attach accept msg of MME, The srsUE crash down.
<img width="872" alt="image" src="https://user-images.githubusercontent.com/92322753/198832179-269663e2-26ad-44ba-9e03-313a682cb5d7.png">

