### PR TITLE
Optimize inserts C++11 and code simplify

### DIFF
--- a/lib/include/srsran/rlc/rlc.h
+++ b/lib/include/srsran/rlc/rlc.h
@@ -106,7 +106,6 @@ private:
   srsran::timer_handler*     timers = nullptr;
 
   typedef std::map<uint16_t, std::unique_ptr<rlc_common> >  rlc_map_t;
-  typedef std::pair<uint16_t, std::unique_ptr<rlc_common> > rlc_map_pair_t;
 
   rlc_map_t        rlc_array, rlc_array_mrb;
   pthread_rwlock_t rwlock;

--- a/lib/src/rlc/rlc.cc
+++ b/lib/src/rlc/rlc.cc
@@ -449,7 +449,7 @@ int rlc::add_bearer(uint32_t lcid, const rlc_config_t& cnfg)
 
   rlc_entity->set_bsr_callback(bsr_callback);
 
-  if (not rlc_array.insert(rlc_map_pair_t(lcid, std::move(rlc_entity))).second) {
+  if (not rlc_array.emplace(lcid, std::move(rlc_entity)).second) {
     logger.error("Error inserting RLC entity in to array.");
     return SRSRAN_ERROR;
   }
@@ -472,7 +472,7 @@ int rlc::add_bearer_mrb(uint32_t lcid)
     }
     rlc_entity->set_bsr_callback(bsr_callback);
     if (rlc_array_mrb.count(lcid) == 0) {
-      if (not rlc_array_mrb.insert(rlc_map_pair_t(lcid, std::move(rlc_entity))).second) {
+      if (not rlc_array_mrb.emplace(lcid, std::move(rlc_entity)).second) {
         logger.error("Error inserting RLC entity in to array.");
         return SRSRAN_ERROR;
       }
@@ -522,7 +522,7 @@ void rlc::change_lcid(uint32_t old_lcid, uint32_t new_lcid)
     // insert old rlc entity into new LCID
     rlc_map_t::iterator         it         = rlc_array.find(old_lcid);
     std::unique_ptr<rlc_common> rlc_entity = std::move(it->second);
-    if (not rlc_array.insert(rlc_map_pair_t(new_lcid, std::move(rlc_entity))).second) {
+    if (not rlc_array.emplace(new_lcid, std::move(rlc_entity)).second) {
       logger.error("Error inserting RLC entity into array.");
       return;
     }

--- a/srsepc/src/mme/mme_gtpc.cc
+++ b/srsepc/src/mme/mme_gtpc.cc
@@ -183,13 +183,13 @@ bool mme_gtpc::send_create_session_request(uint64_t imsi)
   }
 
   // Save RX Control TEID
-  m_mme_ctr_teid_to_imsi.insert(std::pair<uint32_t, uint64_t>(cs_req->sender_f_teid.teid, imsi));
+  m_mme_ctr_teid_to_imsi.emplace(cs_req->sender_f_teid.teid, imsi);
 
   // Save GTP-C context
   gtpc_ctx_t gtpc_ctx;
   std::memset(&gtpc_ctx, 0, sizeof(gtpc_ctx_t));
   gtpc_ctx.mme_ctr_fteid = cs_req->sender_f_teid;
-  m_imsi_to_gtpc_ctx.insert(std::pair<uint64_t, gtpc_ctx_t>(imsi, gtpc_ctx));
+  m_imsi_to_gtpc_ctx.emplace(imsi, gtpc_ctx);
 
   // Send msg to SPGW
   send_s11_pdu(cs_req_pdu);

--- a/srsepc/src/mme/s1ap.cc
+++ b/srsepc/src/mme/s1ap.cc
@@ -317,9 +317,9 @@ void s1ap::add_new_enb_ctx(const enb_ctx_t& enb_ctx, const struct sctp_sndrcvinf
   std::set<uint32_t> ue_set;
   enb_ctx_t*         enb_ptr = new enb_ctx_t;
   *enb_ptr                   = enb_ctx;
-  m_active_enbs.insert(std::pair<uint16_t, enb_ctx_t*>(enb_ptr->enb_id, enb_ptr));
-  m_sctp_to_enb_id.insert(std::pair<int32_t, uint16_t>(enb_sri->sinfo_assoc_id, enb_ptr->enb_id));
-  m_enb_assoc_to_ue_ids.insert(std::pair<int32_t, std::set<uint32_t> >(enb_sri->sinfo_assoc_id, ue_set));
+  m_active_enbs.emplace(enb_ptr->enb_id, enb_ptr);
+  m_sctp_to_enb_id.emplace(enb_sri->sinfo_assoc_id, enb_ptr->enb_id);
+  m_enb_assoc_to_ue_ids.emplace(enb_sri->sinfo_assoc_id, ue_set);
 }
 
 enb_ctx_t* s1ap::find_enb_ctx(uint16_t enb_id)
@@ -371,7 +371,7 @@ bool s1ap::add_nas_ctx_to_imsi_map(nas* nas_ctx)
       return false;
     }
   }
-  m_imsi_to_nas_ctx.insert(std::pair<uint64_t, nas*>(nas_ctx->m_emm_ctx.imsi, nas_ctx));
+  m_imsi_to_nas_ctx.emplace(nas_ctx->m_emm_ctx.imsi, nas_ctx);
   m_logger.debug("Saved UE context corresponding to IMSI %015" PRIu64 "", nas_ctx->m_emm_ctx.imsi);
   return true;
 }
@@ -394,7 +394,7 @@ bool s1ap::add_nas_ctx_to_mme_ue_s1ap_id_map(nas* nas_ctx)
       return false;
     }
   }
-  m_mme_ue_s1ap_id_to_nas_ctx.insert(std::pair<uint32_t, nas*>(nas_ctx->m_ecm_ctx.mme_ue_s1ap_id, nas_ctx));
+  m_mme_ue_s1ap_id_to_nas_ctx.emplace(nas_ctx->m_ecm_ctx.mme_ue_s1ap_id, nas_ctx);
   m_logger.debug("Saved UE context corresponding to MME UE S1AP Id %d", nas_ctx->m_ecm_ctx.mme_ue_s1ap_id);
   return true;
 }
@@ -560,7 +560,7 @@ uint32_t s1ap::allocate_m_tmsi(uint64_t imsi)
   uint32_t m_tmsi = m_next_m_tmsi;
   m_next_m_tmsi   = (m_next_m_tmsi + 1) % UINT32_MAX;
 
-  m_tmsi_to_imsi.insert(std::pair<uint32_t, uint64_t>(m_tmsi, imsi));
+  m_tmsi_to_imsi.emplace(m_tmsi, imsi);
   m_logger.debug("Allocated M-TMSI 0x%x to IMSI %015" PRIu64 ",", m_tmsi, imsi);
   return m_tmsi;
 }

--- a/srsepc/src/spgw/gtpc.cc
+++ b/srsepc/src/spgw/gtpc.cc
@@ -464,8 +464,8 @@ spgw_tunnel_ctx_t* spgw::gtpc::create_gtpc_ctx(const struct srsran::gtpc_create_
   tunnel_ctx->dw_ctrl_fteid.ipv4 = cs_req.sender_f_teid.ipv4;
   std::memset(&tunnel_ctx->dw_user_fteid, 0, sizeof(srsran::gtp_fteid_t));
 
-  m_teid_to_tunnel_ctx.insert(std::pair<uint32_t, spgw_tunnel_ctx_t*>(spgw_uplink_ctrl_teid, tunnel_ctx));
-  m_imsi_to_ctr_teid.insert(std::pair<uint64_t, uint32_t>(cs_req.imsi, spgw_uplink_ctrl_teid));
+  m_teid_to_tunnel_ctx.emplace(spgw_uplink_ctrl_teid, tunnel_ctx);
+  m_imsi_to_ctr_teid.emplace(cs_req.imsi, spgw_uplink_ctrl_teid);
   return tunnel_ctx;
 }
 


### PR DESCRIPTION
@andrepuschmann,
Most people compile with C++11 standard and more, I think this PR changes will make it easier to read code and optimize insertion in some compilers.