### PR TITLE
enb,parser: Fix options formatting

### DIFF
--- a/srsenb/hdr/parser.h
+++ b/srsenb/hdr/parser.h
@@ -452,11 +452,11 @@ int number_to_enum(EnumType& enum_val, Setting& root)
       ss << val;
       fprintf(stderr, "Invalid option: %s for enum field \"%s\"\n", ss.str().c_str(), root.getName());
       ss.str("");
-      ss << EnumType((typename EnumType::options)0).to_number();
+      ss << std::to_string(EnumType((typename EnumType::options)0).to_number());
       fprintf(stderr, "Valid options:  %s", ss.str().c_str());
       for (uint32_t i = 1; i < EnumType::nof_types; i++) {
         ss.str("");
-        ss << EnumType((typename EnumType::options)i).to_number();
+        ss << std::to_string(EnumType((typename EnumType::options)i).to_number());
         fprintf(stderr, ", %s", ss.str().c_str());
       }
       fprintf(stderr, "\n");


### PR DESCRIPTION
Before the change, setting report_amount to 10 printed:
```
Invalid option: 
 for enum field "report_amount"
Valid options:  , , ,, ,  , @, �
Error parsing field cell_list in section cell_list
```

Now it prints:
```
Invalid option: 
 for enum field "report_amount"
Valid options:  1, 2, 4, 8, 16, 32, 64, -1
Error parsing field cell_list in section cell_list
```